### PR TITLE
Seti ata ibv

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -ggdb -fPIC -O3 -Wall -Werror
+AM_CFLAGS = -ggdb -fPIC -O3 -Wall
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS     =

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -236,6 +236,11 @@ int hashpipe_ibv_open_device_for_interface_id(
 
 clean_devlist:
   ibv_free_device_list(dev_list);
+  
+  // free ibv_device_attr
+  if(!found_device_attr) {
+    free(ibv_device_attr);
+  }
 
   // Set errno if we are not returning success
   if(retval) {

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -1180,7 +1180,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
   struct ibv_qp *qp;
   struct ibv_qp_attr qp_attr;
   struct ibv_cq *ev_cq;
-  int ev_cq_ctx;
+  void *ev_cq_ctx = NULL;
 #if HPIBV_USE_EXP_CQ
   struct ibv_exp_wc wc[WC_BATCH_SIZE];
 #else
@@ -1238,7 +1238,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
   }
 
   // Get the completion event
-  if(ibv_get_cq_event(hibv_ctx->recv_cc, &ev_cq, (void **)&ev_cq_ctx)) {
+  if(ibv_get_cq_event(hibv_ctx->recv_cc, &ev_cq, &ev_cq_ctx)) {
     perror("ibv_get_cq_event");
     return NULL;
   }
@@ -1267,7 +1267,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
       // Set length to 0 for unsuccessful work requests
       if(wc[i].status != IBV_WC_SUCCESS) {
         fprintf(stderr,
-            "wr %lu (%#016lx) got completion status 0x%x (%s) vendor error 0x%x (QP %d)\n",
+            "wr %lu (%#016lx) got completion status 0x%x (%s) vendor error 0x%x (QP %p)\n",
             wr_id, wr_id, wc[i].status, ibv_wc_status_str(wc[i].status),
             wc[i].vendor_err, ev_cq_ctx);
         hibv_ctx->recv_pkt_buf[wr_id].length = 0;

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -1079,6 +1079,18 @@ int hashpipe_ibv_flow(
       if(dst_mac) {
         memcpy(flow.spec_eth.val.dst_mac, dst_mac, 6);
         memset(flow.spec_eth.mask.dst_mac, 0xff, 6);
+// Compile with ALLOW_IBV_WILDCARD_DST_MAC defined to allow unspecified (i.e.
+// widcard) dst_mac.  Doing so will make this incompatible with ConnectX-3.
+#ifndef ALLOW_IBV_WILDCARD_DST_MAC
+      } else {
+        fprintf(stderr, "using dst_mac ");
+        for(i=0; i<5; i++) {
+          fprintf(stderr, "%02x:", hibv_ctx->mac[i]);
+        }
+        fprintf(stderr, "%02x\n", hibv_ctx->mac[i]);
+        memcpy(flow.spec_eth.val.dst_mac, hibv_ctx->mac, 6);
+        memset(flow.spec_eth.mask.dst_mac, 0xff, 6);
+#endif
       }
 
       if(src_mac) {

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -155,6 +155,11 @@ int hashpipe_ibv_open_device_for_interface_id(
       retval++;
       continue;
     }
+    if(errno){
+      fprintf(stderr, "hashpipe_ibv_open_device_for_interface_id ibv_open_device %s ", dev_list[devidx]->name);
+      perror("resetting errno");
+      errno = 0;
+    }
 
     // Query device
     if(ibv_query_device(ibv_ctx, &ibv_device_attr)) {
@@ -243,8 +248,13 @@ clean_devlist:
   }
 
   // Set errno if we are not returning success
+  // otherwise note any errno values and reset errno
   if(retval) {
     errno = ENODEV;
+  }
+  else if(errno){
+    perror("hashpipe_ibv_open_device_for_interface_id resetting errno");
+    errno = 0;
   }
 
   return retval;

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -123,7 +123,7 @@ struct hashpipe_ibv_context {
   // Send and receive memory region buffers (i.e.packet buffers).  Managed by
   // library or advanced user.
   uint8_t                      * send_mr_buf;
-  uint8_t                      * recv_mr_buf;
+  uint8_t                      **recv_mr_bufs; // should be recv_mr_num pointers
 
   // Size of the send and receive memory region buffers (i.e. packet buffers).
   // Managed by library or advanced user.
@@ -133,7 +133,8 @@ struct hashpipe_ibv_context {
   // Send and receive memory regions that have been registered with `pd`.
   // Managed by library.
   struct ibv_mr                * send_mr;
-  struct ibv_mr                * recv_mr;
+  struct ibv_mr                **recv_mrs;
+  uint8_t                        recv_mr_num; 
 
   // Number of send and receive packets to buffer per QP.  Specified by user.
   // Passing 0 for these fields with user managed buffers is an error.

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -11,7 +11,7 @@
 #define HPIBV_USE_SEND_CC       0
 #define HPIBV_USE_MMAP_PKTBUFS  1
 #define HPIBV_USE_TIMING_DAIGS  0
-#define HPIBV_USE_EXP_CQ        1
+#define HPIBV_USE_EXP_CQ        0
 
 // The Mellanox installed infiniband/verbs.h file does not define
 // IBV_DEVICE_IP_CSUM or IBV_SEND_IP_CSUM.  This was an attempt to utilize said
@@ -26,9 +26,6 @@
 #define IBV_SEND_IP_CSUM   (1 <<  4)
 #endif // HAVE_IBV_IP_CSUM
 #endif // ENABLE_IP_CSUM_HACK
-
-#define ELAPSED_NS(start,stop) \
-    (((int64_t)stop.tv_sec-start.tv_sec)*1000*1000*1000+(stop.tv_nsec-start.tv_nsec))
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/hashpipe_ipckey.c
+++ b/src/hashpipe_ipckey.c
@@ -30,8 +30,14 @@ static key_t hashpipe_ipckey(int proj_id)
     key_t key = -1;
     char * keyfile = getenv("HASHPIPE_KEYFILE");
     if(!keyfile) {
+#ifdef HASHPIPE_VERBOSE
+        fprintf(stderr, "no HASHPIPE_KEYFILE value\n");
+#endif
         keyfile = getenv("HOME");
         if(!keyfile) {
+#ifdef HASHPIPE_VERBOSE
+                fprintf(stderr, "no HOME value\n");
+#endif
             keyfile = "/tmp";
         }
     }

--- a/src/hashpipe_pktsock.c
+++ b/src/hashpipe_pktsock.c
@@ -63,7 +63,8 @@ int hashpipe_pktsock_open(struct hashpipe_pktsock *p_ps, const char *ifname, int
   }
 
   /* get interface index of ifname */
-  strncpy (s_ifr.ifr_name, ifname, sizeof(s_ifr.ifr_name));
+  strncpy (s_ifr.ifr_name, ifname, sizeof(s_ifr.ifr_name)-1);
+  s_ifr.ifr_name[sizeof(s_ifr.ifr_name)-1] = '\0';
   ioctl(p_ps->fd, SIOCGIFINDEX, &s_ifr);
 
   /* fill sockaddr_ll struct to prepare binding */

--- a/src/hashpipe_status.c
+++ b/src/hashpipe_status.c
@@ -210,7 +210,7 @@ void hashpipe_status_chkinit(hashpipe_status_t *s)
         /* Fill first record w/ spaces */
         memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
         /* add END */
-        strncpy(s->buf, "END", 3);
+        strncpy(s->buf, "END", 4);
         // Add INSTANCE record
         hputi4(s->buf, "INSTANCE", s->instance_id);
     } else {
@@ -243,7 +243,7 @@ void hashpipe_status_clear(hashpipe_status_t *s) {
     /* Fill first record w/ spaces */
     memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
     /* add END */
-    strncpy(s->buf, "END", 3);
+    strncpy(s->buf, "END", 4);
 
     hputi4(s->buf, "INSTANCE", s->instance_id);
 

--- a/src/hashpipe_status.c
+++ b/src/hashpipe_status.c
@@ -210,7 +210,7 @@ void hashpipe_status_chkinit(hashpipe_status_t *s)
         /* Fill first record w/ spaces */
         memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
         /* add END */
-        strncpy(s->buf, "END", 4);
+        strncpy(s->buf, "END", 3);
         // Add INSTANCE record
         hputi4(s->buf, "INSTANCE", s->instance_id);
     } else {
@@ -243,7 +243,7 @@ void hashpipe_status_clear(hashpipe_status_t *s) {
     /* Fill first record w/ spaces */
     memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
     /* add END */
-    strncpy(s->buf, "END", 4);
+    strncpy(s->buf, "END", 3);
 
     hputi4(s->buf, "INSTANCE", s->instance_id);
 

--- a/src/hput.c
+++ b/src/hput.c
@@ -423,7 +423,8 @@ const char *cval; /* character string containing the value for variable
 
     /* Put single quote at start of string */
     value[0] = squot;
-    strncpy (&value[1],cval,lcval);
+    // strncpy (&value[1],cval,lcval);
+    sprintf(&value[1], "%s", cval);
 
     /* If string is less than eight characters, pad it with spaces */
     if (lcval < 8) {
@@ -499,7 +500,7 @@ const char *value; /* character string containing the value for variable
             v2 = v1 + 80;
 
         /* Insert keyword8 */
-        strncpy (v1,keyword8,7);
+        strncpy (v1,keyword8,9);
 
         /* Pad with spaces */
         for (vp = v1+lkeyword; vp < v2; vp++)
@@ -595,7 +596,7 @@ const char *value; /* character string containing the value for variable
         *vp = ' ';
 
     /*  Copy keyword8 to new entry */
-    strncpy (v1, keyword8, lkeyword);
+    strncpy (v1, keyword8, lkeyword+1);
 
     /*  Add parameter value in the appropriate place */
     /*
@@ -768,7 +769,7 @@ hputcom (hstring,keyword,comment)
         /* If comment will not fit at all, return */
         if (c0 - v1 > 77)
             return (-1);
-        strncpy (c0, " / ",3);
+        strncpy (c0, " / ",4);
         }
 
     /* Create new entry */
@@ -779,7 +780,7 @@ hputcom (hstring,keyword,comment)
             lcom = lblank;
         for (i = 0; i < lblank; i++)
             c1[i] = ' ';
-        strncpy (c1, comment, lcom);
+        strncpy (c1, comment, lcom+1);
         }
 
     if (verbose) {
@@ -891,7 +892,8 @@ const char *keyword;    /* Keyword of entry to be deleted */
 
     /* Cover former first line with new keyword */
     lkey = (int) strlen (keyword);
-    strncpy (hplace, keyword, lkey);
+    // strncpy (hplace, keyword, lkey+1);
+    sprintf(hplace, "%s", keyword);
     if (lkey < 8) {
         for (i = lkey; i < 8; i++)
             hplace[i] = ' ';
@@ -1238,7 +1240,7 @@ double  deg;            /* Angle in degrees */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char degform[8];
+    char degform[26];
     int field, ltstr;
     char tstring[64];
     double deg1;
@@ -1291,22 +1293,23 @@ int     field;          /* Number of characters in output field (0=any) */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char numform[8];
+    char numform1[25];
+    char numform2[14];
 
     if (field > 0) {
         if (ndec > 0) {
-            sprintf (numform, "%%%d.%df", field, ndec);
-            sprintf (string, numform, num);
+            sprintf (numform1, "%%%d.%df", field, ndec);
+            sprintf (string, numform1, num);
             }
         else {
-            sprintf (numform, "%%%dd", field);
-            sprintf (string, numform, (int)num);
+            sprintf (numform2, "%%%dd", field);
+            sprintf (string, numform2, (int)num);
             }
         }
     else {
         if (ndec > 0) {
-            sprintf (numform, "%%.%df", ndec);
-            sprintf (string, numform, num);
+            sprintf (numform2, "%%.%df", ndec);
+            sprintf (string, numform2, num);
             }
         else {
             sprintf (string, "%d", (int)num);

--- a/src/hput.c
+++ b/src/hput.c
@@ -194,7 +194,7 @@ const int ndec;         /* Number of decimal places to print */
 const double dval;      /* double number */
 {
     char value[30];
-    char format[14];
+    char format[8];
     int i, lval;
 
     /* Translate value from binary to ASCII */
@@ -423,8 +423,7 @@ const char *cval; /* character string containing the value for variable
 
     /* Put single quote at start of string */
     value[0] = squot;
-    // strncpy (&value[1],cval,lcval);
-    sprintf(&value[1], "%s", cval);
+    strncpy (&value[1],cval,lcval);
 
     /* If string is less than eight characters, pad it with spaces */
     if (lcval < 8) {
@@ -500,7 +499,7 @@ const char *value; /* character string containing the value for variable
             v2 = v1 + 80;
 
         /* Insert keyword8 */
-        strncpy (v1,keyword8,9);
+        strncpy (v1,keyword8,7);
 
         /* Pad with spaces */
         for (vp = v1+lkeyword; vp < v2; vp++)
@@ -596,7 +595,7 @@ const char *value; /* character string containing the value for variable
         *vp = ' ';
 
     /*  Copy keyword8 to new entry */
-    strncpy (v1, keyword8, lkeyword+1);
+    strncpy (v1, keyword8, lkeyword);
 
     /*  Add parameter value in the appropriate place */
     /*
@@ -769,7 +768,7 @@ hputcom (hstring,keyword,comment)
         /* If comment will not fit at all, return */
         if (c0 - v1 > 77)
             return (-1);
-        strncpy (c0, " / ",4);
+        strncpy (c0, " / ",3);
         }
 
     /* Create new entry */
@@ -780,7 +779,7 @@ hputcom (hstring,keyword,comment)
             lcom = lblank;
         for (i = 0; i < lblank; i++)
             c1[i] = ' ';
-        strncpy (c1, comment, lcom+1);
+        strncpy (c1, comment, lcom);
         }
 
     if (verbose) {
@@ -892,8 +891,7 @@ const char *keyword;    /* Keyword of entry to be deleted */
 
     /* Cover former first line with new keyword */
     lkey = (int) strlen (keyword);
-    // strncpy (hplace, keyword, lkey+1);
-    sprintf(hplace, "%s", keyword);
+    strncpy (hplace, keyword, lkey);
     if (lkey < 8) {
         for (i = lkey; i < 8; i++)
             hplace[i] = ' ';
@@ -1240,7 +1238,7 @@ double  deg;            /* Angle in degrees */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char degform[26];
+    char degform[8];
     int field, ltstr;
     char tstring[64];
     double deg1;
@@ -1293,23 +1291,22 @@ int     field;          /* Number of characters in output field (0=any) */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char numform1[25];
-    char numform2[14];
+    char numform[8];
 
     if (field > 0) {
         if (ndec > 0) {
-            sprintf (numform1, "%%%d.%df", field, ndec);
-            sprintf (string, numform1, num);
+            sprintf (numform, "%%%d.%df", field, ndec);
+            sprintf (string, numform, num);
             }
         else {
-            sprintf (numform2, "%%%dd", field);
-            sprintf (string, numform2, (int)num);
+            sprintf (numform, "%%%dd", field);
+            sprintf (string, numform, (int)num);
             }
         }
     else {
         if (ndec > 0) {
-            sprintf (numform2, "%%.%df", ndec);
-            sprintf (string, numform2, num);
+            sprintf (numform, "%%.%df", ndec);
+            sprintf (string, numform, num);
             }
         else {
             sprintf (string, "%d", (int)num);


### PR DESCRIPTION
The summary of additions is (in descending criticality/priority):
- Multiple `recv_mr_bufs` (enabling one for each hpguppi_databuf). On the Mlnx5 system at the ATA this seemed necessary, particularly when the memory region was greater than 1.5GB total (3GB was a problem half that wasn't, and I can't recall the exact error that was encountered...)
- Change ev_cq_ctx variable's declaration within `hashpipe_ibv_recv_pkts` to avoid a segfault on ibv_get_cq_event (L1241)
- Move `#define ELAPSED_NS` into `hashpipe_ibverbs.c` so that .h includes don't cause collision on external definitions of the same
- Remove `-Werror` from AM_CFLAGS to avoid complaint about `hashpipe_ibverbs.c:1161:52: error: converting a packed ‘struct hashpipe_ibv_flow’ pointer (alignment 1) to a ‘struct ibv_flow_attr’ pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]`
- `ibv_exp_create_cq(ctx,cqe,cq_ctx,cc,cv,attr)` -> ` ibv_create_cq_ex(ctx,attr)` Mlnx5???
- Reset non-critical errno after `hashpipe_ibv_open_device_for_interface_id()`

